### PR TITLE
fix: don't install kuberhealthy by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -64,5 +64,5 @@ variable "nginx_chart_version" {
 variable "install_kuberhealthy" {
   description = "Flag to specify if kuberhealthy operator should be installed"
   type        = bool
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
kuberhealthy isn't working in current EKS versions